### PR TITLE
Remove unused organization read permission from workflow permissions

### DIFF
--- a/.github/workflows/delete-spam-comments.yml
+++ b/.github/workflows/delete-spam-comments.yml
@@ -14,7 +14,6 @@ permissions:
   id-token: write
   issues: write
   contents: read
-  organization: read
 
 jobs:
   authorize:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Remove unused organization read permission from workflow permissions

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
