### PR TITLE
fix: use ESM export for Jest config

### DIFF
--- a/scripts/jest.config.js
+++ b/scripts/jest.config.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   preset: 'ts-jest',
   testEnvironment: 'node',
   roots: ['<rootDir>'],


### PR DESCRIPTION
## Summary
- update the Jest config to use an ESM default export
- fix `npm test` failing under the package-level `type: module` setting

## Verification
- `npm run build`
- `npm test -- --runInBand`

Duplicate check: searched open and closed/merged PRs and issues for `scripts/jest.config.js`, `module is not defined`, `npm test`, and ESM/CommonJS Jest config fixes; no overlapping PR found.